### PR TITLE
Typed arguments

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -1,8 +1,15 @@
+import {IArgsList} from './parse'
+
 export type ParseFn<T> = (input: string) => T
 
+export type NameOf<T> =
+    T extends {name: string} ? T['name'] :
+    T extends Arg<infer N, infer _> ? N :
+    never;
+
 // eslint-disable-next-line @typescript-eslint/interface-name-prefix
-export interface IArg<T = string> {
-  name: string;
+export interface IArg<N extends string, T = string> {
+  name: N;
   description?: string;
   required?: boolean;
   hidden?: boolean;
@@ -11,8 +18,8 @@ export interface IArg<T = string> {
   options?: string[];
 }
 
-export interface ArgBase<T> {
-  name?: string;
+export interface ArgBase<N extends string, T> {
+  name?: N;
   description?: string;
   hidden?: boolean;
   parse: ParseFn<T>;
@@ -21,27 +28,26 @@ export interface ArgBase<T> {
   options?: string[];
 }
 
-export type RequiredArg<T> = ArgBase<T> & {
+export type RequiredArg<N extends string, T> = ArgBase<N, T> & {
   required: true;
   value: T;
 }
 
-export type OptionalArg<T> = ArgBase<T> & {
+export type OptionalArg<N extends string, T> = ArgBase<N, T> & {
   required: false;
   value?: T;
 }
 
-export type Arg<T> = RequiredArg<T> | OptionalArg<T>
+export type Arg<N extends string, T> = RequiredArg<N, T> | OptionalArg<N, T>
 
-export function newArg<T>(arg: IArg<T> & { Parse: ParseFn<T> }): Arg<T>
-export function newArg(arg: IArg): Arg<string>
-export function newArg(arg: IArg<any>): any {
+export function newArg<N extends string, T>(arg: IArg<N, T> & { Parse: ParseFn<T> }): Arg<NameOf<typeof arg>, T>
+export function newArg<N extends string>(arg: IArg<N>): Arg<NameOf<typeof arg>, string>
+export function newArg(arg: IArg<any, any>): Arg<NameOf<typeof arg>, any> {
   return {
     parse: (i: string) => i,
     ...arg,
     required: Boolean(arg.required),
-  }
+  } as any
 }
 
-export interface Output {[name: string]: any}
-export type Input = IArg<any>[]
+export type Input = IArgsList;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -20,7 +20,7 @@ const m = Deps()
 export interface ICLIParseErrorOptions {
   parse: {
     input?: ParserInput;
-    output?: ParserOutput<any, any>;
+    output?: ParserOutput<any>;
   };
 }
 
@@ -35,9 +35,9 @@ export class CLIParseError extends CLIError {
 }
 
 export class InvalidArgsSpecError extends CLIParseError {
-  public args: Arg<any>[]
+  public args: Arg<any, any>[]
 
-  constructor({args, parse}: ICLIParseErrorOptions & { args: Arg<any>[] }) {
+  constructor({args, parse}: ICLIParseErrorOptions & { args: Arg<any, any>[] }) {
     let message = 'Invalid argument spec'
     const namedArgs = args.filter(a => a.name)
     if (namedArgs.length > 0) {
@@ -50,9 +50,9 @@ export class InvalidArgsSpecError extends CLIParseError {
 }
 
 export class RequiredArgsError extends CLIParseError {
-  public args: Arg<any>[]
+  public args: Arg<any, any>[]
 
-  constructor({args, parse}: ICLIParseErrorOptions & { args: Arg<any>[] }) {
+  constructor({args, parse}: ICLIParseErrorOptions & { args: Arg<any, any>[] }) {
     let message = `Missing ${args.length} required arg${args.length === 1 ? '' : 's'}`
     const namedArgs = args.filter(a => a.name)
     if (namedArgs.length > 0) {
@@ -93,7 +93,7 @@ export class FlagInvalidOptionError extends CLIParseError {
 }
 
 export class ArgInvalidOptionError extends CLIParseError {
-  constructor(arg: Arg<any>, input: string) {
+  constructor(arg: Arg<any, any>, input: string) {
     const message = `Expected ${input} to be one of: ${arg.options!.join(', ')}`
     super({parse: {}, message})
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,13 @@
 import * as args from './args'
 import Deps from './deps'
 import * as flags from './flags'
-import {OutputArgs, OutputFlags, Parser, ParserOutput as Output} from './parse'
+import {
+  OutputArgs,
+  OutputFlags,
+  Parser,
+  ParserRawInput as Input,
+  ParserOutput as Output,
+} from './parse'
 import * as Validate from './validate'
 export {args}
 export {flags}
@@ -14,19 +20,16 @@ const m = Deps()
 // eslint-disable-next-line node/no-missing-require
 .add('validate', () => require('./validate').validate as typeof Validate.validate)
 
-export type Input<TFlags extends flags.Output> = {
-  flags?: flags.Input<TFlags>;
-  args?: args.Input;
-  strict?: boolean;
-  context?: any;
-  '--'?: boolean;
-}
+export type FlagsOf<T extends Input<any>['flags'] | undefined> =
+    T extends undefined ? undefined :
+    T extends Input<infer TFlags> ? OutputFlags<TFlags> :
+    never;
 
-export function parse<TFlags, TArgs extends {[name: string]: string}>(argv: string[], options: Input<TFlags>): Output<TFlags, TArgs> {
+export function parse<TInput extends Input<any>>(argv: string[], options: TInput): Output<TInput> {
   const input = {
     argv,
     context: options.context,
-    args: (options.args || []).map((a: any) => args.newArg(a as any)),
+    args: (options.args || []).map(a => args.newArg(a)),
     '--': options['--'],
     flags: {
       color: flags.defaultFlags.color,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -26,12 +26,15 @@ try {
   debug = () => {}
 }
 
+type DefaultOf<T> = T extends { default: () => infer Default } ? Default
+  : T extends { default: infer Default } ? Default
+  : never;
 type RequiredTypeOf<T, N extends string = NameOf<T>> = T extends {
   name: N;
   parse: (raw: string) => infer R;
 }
-  ? {[key in N]: R}
-  : {[key in N]: string};
+  ? {[key in N]: R | DefaultOf<T>}
+  : {[key in N]: string | DefaultOf<T>};
 
 type TypeOf<T> = T extends {required: true}
   ? RequiredTypeOf<T>
@@ -45,8 +48,6 @@ type UnionToIntersection<U> =
   (U extends any ? (k: U) => void : never) extends ((k: infer I) => void)
   ? I
   : never;
-
-type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
 export type ParserRawInput<TFlags extends flags.Output> = {
   flags?: flags.Input<TFlags>;

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -4,7 +4,7 @@ import {Arg} from './args'
 import {InvalidArgsSpecError, RequiredArgsError, RequiredFlagError, UnexpectedArgsError} from './errors'
 import {ParserInput, ParserOutput} from './parse'
 
-export function validate(parse: { input: ParserInput; output: ParserOutput<any, any> }) {
+export function validate(parse: { input: ParserInput; output: ParserOutput<any> }) {
   function validateArgs() {
     const maxArgs = parse.input.args.length
     if (parse.input.strict && parse.output.argv.length > maxArgs) {
@@ -12,7 +12,7 @@ export function validate(parse: { input: ParserInput; output: ParserOutput<any, 
       throw new UnexpectedArgsError({parse, args: extras})
     }
 
-    const missingRequiredArgs: Arg<any>[] = []
+    const missingRequiredArgs: Arg<any, any>[] = []
     let hasOptional = false
 
     parse.input.args.forEach((arg, index) => {

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -442,12 +442,12 @@ See more help with --help`)
       expect(out.flags).to.deep.include({foo: 'bar'})
     })
 
-    // it('accepts falsy', () => {
-    //   const out = parse([], {
-    //     args: [{name: 'baz' as const, default: false}],
-    //   })
-    //   expect(out.args).to.deep.include({baz: false})
-    // })
+    it('accepts falsy', () => {
+      const out = parse([], {
+        args: [{name: 'baz' as const, default: false}],
+      })
+      expect(out.args).to.deep.include({baz: false})
+    })
 
     it('default as function', () => {
       const out = parse([], {

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -442,12 +442,12 @@ See more help with --help`)
       expect(out.flags).to.deep.include({foo: 'bar'})
     })
 
-    it('accepts falsy', () => {
-      const out = parse([], {
-        args: [{name: 'baz', default: false}],
-      })
-      expect(out.args).to.deep.include({baz: false})
-    })
+    // it('accepts falsy', () => {
+    //   const out = parse([], {
+    //     args: [{name: 'baz' as const, default: false}],
+    //   })
+    //   expect(out.args).to.deep.include({baz: false})
+    // })
 
     it('default as function', () => {
       const out = parse([], {
@@ -578,7 +578,7 @@ See more help with --help`)
   describe('arg options', () => {
     it('accepts valid option', () => {
       const out = parse(['myotheropt'], {
-        args: [{name: 'foo', options: ['myopt', 'myotheropt']}],
+        args: [{name: 'foo' as const, options: ['myopt', 'myotheropt']}],
       })
       expect(out.args.foo).to.equal('myotheropt')
     })


### PR DESCRIPTION
See https://github.com/oclif/oclif/issues/301

Instead of doing `args as const` we can do `name: "name" as const` to ensure the name is kept; if that's omitted then you still get a map type for the `args` property. Non-string arg types can be inferred from the results of `parser` functions or `default` values.